### PR TITLE
Cache package.json require statement

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ const express = require( 'express' );
 const compression = require( 'compression' );
 const prettyBytes = require( 'pretty-bytes' );
 const favicon = require( 'serve-favicon' );
+const pkgInfo = require( '../package.json' );
 const padRight = require( './utils/padRight.js' );
 const servePackage = require( './serve-package.js' );
 const logger = require( './logger.js' );
@@ -109,7 +110,7 @@ app.use( express.static( `${root}/public`, {
 app.get( '/', ( req, res ) => {
 	res.status( 200 );
 	const index = fs.readFileSync( `${root}/server/templates/index.html`, 'utf-8' )
-		.replace( '__VERSION__', require( '../package.json' ).version );
+		.replace( '__VERSION__', pkgInfo.version );
 
 	res.end( index );
 });


### PR DESCRIPTION
Hi, 

I was ready the code and thought the `require` statement can be cached for `package.json` as the file content doesn't change on runtime and doesn't need to be `require`d each time.

Thanks!