### PR TITLE
Use prod env in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ node_js:
 env:
   global:
     - BUILD_TIMEOUT=10000
+    - NODE_ENV=production
 install: npm install

--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "serve-favicon": "^2.4.2",
     "tar": "^3.1.5",
     "tar.gz": "^1.0.5",
+    "request": "^2.81.0",
+    "request-promise": "^4.2.1",
     "uglify-js": "^3.0.25"
   },
   "devDependencies": {
     "eslint": "^4.3.0",
-    "request": "^2.81.0",
-    "request-promise": "^4.2.1",
     "serve-static": "^1.12.1"
   },
   "now": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "uglify-js": "^3.0.25"
   },
   "devDependencies": {
-    "eslint": "^4.3.0",
-    "serve-static": "^1.12.1"
+    "eslint": "^4.3.0"
   },
   "now": {
     "alias": "packd",


### PR DESCRIPTION
I set `NODE_ENV=production` to run the application in production, some runtime dependencies were in dev.

This prevents me from updating bundle.run with your last PRs.