### PR TITLE
show errors on 500 page

### DIFF
--- a/server/serve-package.js
+++ b/server/serve-package.js
@@ -88,7 +88,10 @@ module.exports = function servePackage ( req, res, next ) {
 		.catch( err => {
 			logger.error( `[${qualified}] ${err.message}` );
 			res.status( 500 );
-			res.end( sander.readFileSync( `${root}/server/templates/500.html`, { encoding: 'utf-8' }) );
+			const page = sander.readFileSync( `${root}/server/templates/500.html`, { encoding: 'utf-8' })
+				.replace( '__ERROR__', err.message );
+
+			res.end( page );
 		});
 };
 

--- a/server/templates/500.html
+++ b/server/templates/500.html
@@ -27,6 +27,13 @@
 		a {
 			color: black;
 		}
+
+		code {
+			color: rgb(200,0,0);
+			background: rgba(200,0,0,0.05);
+			padding: 0.5em 1em;
+			display: block;
+		}
 	</style>
 </head>
 <body>
@@ -34,5 +41,7 @@
 	<h2>server error</h2>
 
 	<p>Please <a href='https://github.com/Rich-Harris/packd/issues'>raise an issue</a>, quoting this URL.</p>
+
+	<code>__ERROR__</code>
 </body>
 </html>


### PR DESCRIPTION
The current 500 page is a bit mysterious, and you have to do some digging to figure out why a particular package is failing to build. Case in point — #23.

This PR adds the error message to the 500 page, so that we can diagnose things more easily.

<img width="556" alt="screen shot 2017-08-06 at 2 44 11 pm" src="https://user-images.githubusercontent.com/1162160/29006020-d3ec9f2c-7ab5-11e7-9c6b-bfb62359b9e6.png">
