### PR TITLE
Added spellcheck property to input element to prevent eager correcting of package names.

### DIFF
--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -100,7 +100,7 @@
 	<main>
 		<h1>packd</h1>
 		<form>
-			<input value='left-pad'>
+			<input value='left-pad' spellcheck='false'>
 			<button><span>↵</span></button>
 		</form>
 


### PR DESCRIPTION
Just a simple fix that actually plagues me on occasion. macOS *thinks* it knows which package I want better than me. 

This should also be respected on Windows in Edge, although I don't have a Windows computer to confirm this at the moment.