### PR TITLE
Use tar module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,18 @@
 {
   "name": "packd",
-  "version": "2.4.0",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
@@ -209,14 +218,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "2.0.3"
-      }
-    },
     "bluebird": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
@@ -254,9 +255,9 @@
       "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
-        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -281,6 +282,7 @@
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.4.0.tgz",
       "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
       "requires": {
+        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -302,7 +304,6 @@
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -459,6 +460,11 @@
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
       }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -1202,17 +1208,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
-      }
-    },
     "function-bind": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
@@ -1511,10 +1506,10 @@
       "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
-        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -1663,15 +1658,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.0",
@@ -1845,9 +1831,9 @@
       }
     },
     "minizlib": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.3.tgz",
-      "integrity": "sha1-1cGr93vhVGGZUuJTM27Mq5sqMvU=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.4.tgz",
+      "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ==",
       "requires": {
         "minipass": "2.2.1"
       }
@@ -1872,6 +1858,7 @@
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "requires": {
+        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -1879,7 +1866,6 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.3.3",
@@ -1888,11 +1874,6 @@
         "through2": "2.0.3",
         "xtend": "4.0.1"
       }
-    },
-    "mout": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
     },
     "ms": {
       "version": "2.0.0",
@@ -1921,6 +1902,7 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.3.0.tgz",
       "integrity": "sha512-ZJsOWVJ25E2C5Qedf4w9ePIv5hrPCdDIsHhq89tRxSJCqyIfDAMh0KoU9xeTu7yHT9ZrxPF7mopq1TCWxtMfkw==",
       "requires": {
+        "JSONStream": "1.3.1",
         "abbrev": "1.1.0",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -1952,7 +1934,6 @@
         "inherits": "2.0.3",
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
-        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
         "libnpx": "9.2.0",
         "lockfile": "1.0.3",
@@ -2020,6 +2001,24 @@
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
         "abbrev": {
           "version": "1.1.0",
           "bundled": true
@@ -2374,24 +2373,6 @@
               "requires": {
                 "read": "1.0.7"
               }
-            }
-          }
-        },
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
             }
           }
         },
@@ -5558,14 +5539,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5591,6 +5564,14 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -5650,12 +5631,13 @@
       }
     },
     "tar": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-3.1.5.tgz",
-      "integrity": "sha512-TKJKz1fqBOZBaIQ/MGRKU0EnTGmKMLy4ReTRgP10AgtfOWBbj9PBg4MgY80GFpqGbs2EzcIctW5gbwbP4woDYg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-3.2.1.tgz",
+      "integrity": "sha512-ZSzds1E0IqutvMU8HxjMaU8eB7urw2fGwTq88ukDOVuUIh0656l7/P7LiVPxhO5kS4flcRJQk8USG+cghQbTUQ==",
       "requires": {
+        "chownr": "1.0.1",
         "minipass": "2.2.1",
-        "minizlib": "1.0.3",
+        "minizlib": "1.0.4",
         "mkdirp": "0.5.1",
         "yallist": "3.0.2"
       },
@@ -5664,35 +5646,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
-        }
-      }
-    },
-    "tar.gz": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.5.tgz",
-      "integrity": "sha1-4a2n5F7yJBtLHuWBI8j0C108G8Q=",
-      "requires": {
-        "bluebird": "2.11.0",
-        "commander": "2.11.0",
-        "fstream": "1.0.11",
-        "mout": "0.11.1",
-        "tar": "2.2.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "sander": "^0.6.0",
     "semver": "^5.3.0",
     "serve-favicon": "^2.4.2",
-    "tar": "^3.1.5",
-    "tar.gz": "^1.0.5",
+    "tar": "^3.2.1",
     "uglify-js": "^3.0.25"
   },
   "devDependencies": {

--- a/server/child-processes/create-bundle.js
+++ b/server/child-processes/create-bundle.js
@@ -1,7 +1,7 @@
 const path = require( 'path' );
 const sander = require( 'sander' );
 const child_process = require( 'child_process' );
-const targz = require( 'tar.gz' );
+const tar = require( 'tar' );
 const request = require( 'request' );
 const browserify = require( 'browserify' );
 const rollup = require( 'rollup' );
@@ -81,7 +81,13 @@ function fetchAndExtract ( pkg, version, dir ) {
 
 			if ( !timedout ) {
 				info( `[${pkg.name}] extracting to ${dir}/package` );
-				targz().extract( `${dir}/package.tgz`, dir ).then( fulfil, reject );
+
+				tar
+					.x({
+						file: `${dir}/package.tgz`,
+						cwd: dir,
+					})
+					.then( fulfil, reject );
 			}
 		});
 	});
@@ -96,7 +102,7 @@ function sanitizePkg ( cwd ) {
 function installDependencies ( cwd ) {
 	const pkg = require( `${cwd}/package.json` );
 
-	const envVariables = npmInstallEnvVars.join(" ")
+	const envVariables = npmInstallEnvVars.join(" ");
 	const installCommand = `${envVariables} ${root}/node_modules/.bin/npm install --production`;
 
 	info( `[${pkg.name}] running ${installCommand}` );


### PR DESCRIPTION
Sometime the extracting of the package tgz was stuck.

I noticed that the module https://www.npmjs.com/package/tar.gz was EOL and replaced it with `tar`. It seems that the problem has been fixed.