### PR TITLE
support ?format=esm query

### DIFF
--- a/server/serve-package.js
+++ b/server/serve-package.js
@@ -47,6 +47,10 @@ module.exports = function servePackage(req, res, next) {
 		return query;
 	}, {});
 
+	if (query.format && (query.format !== 'umd' && query.format !== 'esm')) {
+		return sendBadRequest(res, 'Invalid format (must be umd or esm)');
+	}
+
 	get(`${registry}/${encodeURIComponent(qualified).replace('%40', '@')}`)
 		.then(JSON.parse)
 		.then(meta => {


### PR DESCRIPTION
Closes #97. This would allow Packd to generate ES module bundles in some cases (the ones where Browserify isn't involved), if the URL has `?format=esm`. Valid formats are `esm` and `umd` (the default, meaning this change isn't breaking).

Any thoughts @xtuc / @marcofugaro?